### PR TITLE
Move the web interface to hypertest.zazukoians.org

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -7,7 +7,7 @@ module.exports = {
             { text: 'Home', link: '/' },
             { text: 'Hypertest DSL', link: '/dsl/' },
             { text: 'Tools', link: '/tools/' },
-            { text: 'Web Editor', link: 'http://hypertest.kube.zazuko.com' },
+            { text: 'Web Editor', link: 'https://hypertest.zazukoians.org' },
         ],
         sidebar: {
             '/dsl': [

--- a/docs/tools/readme.md
+++ b/docs/tools/readme.md
@@ -62,7 +62,7 @@ Options:
 
 ## Web Editor
 
-A simple web editor is running at [http://hypertest.kube.zazuko.com/](http://hypertest.kube.zazuko.com/).
+A simple web editor is running at [https://hypertest.zazukoians.org/](https://hypertest.zazukoians.org/).
 
 It can be used to play with all languages supported by Hypertest.
 

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -2,9 +2,15 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hypertest
+  annotations:
+    kubernetes.io/tls-acme: "true"
 spec:
+  tls:
+  - hosts:
+    - hypertest.zazukoians.org
+    secretName: hypertest-zazukoians-org-tls
   rules:
-  - host: hypertest.kube.zazuko.com
+  - host: hypertest.zazukoians.org
     http:
       paths:
       - path: /


### PR DESCRIPTION
I want to deprecate `kube.zazuko.com`, and hypertest is the only thing remaining there. Is it OK if I move it to `hypertest.zazukoians.org`?
Also this PR enables HTTPS on it.